### PR TITLE
Fix wrong size bug in 10.9

### DIFF
--- a/SpectacleUtilities.h
+++ b/SpectacleUtilities.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <ZeroKit/ZeroKit.h>
 
-#define FlipVerticalOriginOfRectInRect(a, b) (b.size.height - (a.origin.y + a.size.height) + ([[NSScreen mainScreen] frame].size.height - b.size.height))
+#define FlipVerticalOriginOfRectInRect(a, b) (b.size.height - (a.origin.y + a.size.height) + ([[[NSScreen screens] objectAtIndex:0] frame].size.height - b.size.height))
 
 #pragma mark -
 


### PR DESCRIPTION
In 10.9 `[NSScreen mainScreen]` could return any screen which is currently active. We need the screen with `(0,0)` coordinate so I changed it too `[[NSScreen screens] objectAtIndex:0]`, which is how it should be done anyway.
