### PR TITLE
Fix half/third cycling for quantized-height windows

### DIFF
--- a/SpectacleWindowPositionCalculator.m
+++ b/SpectacleWindowPositionCalculator.m
@@ -9,8 +9,8 @@
 
 #pragma mark -
 
-#define AlreadyTwoThirdsOfDisplay(a, b) (abs(a.size.width - floor((b.size.width * 2.0f) / 3.0f)) < SpectacleWindowCalculationFudgeFactor) && (a.size.height == b.size.height)
-#define AlreadyOneHalfOfDisplay(a, b) (abs(a.size.width - (b.size.width / 2.0f)) < SpectacleWindowCalculationFudgeFactor) && (a.size.height == b.size.height)
+#define AlreadyTwoThirdsOfDisplay(a, b) (abs(a.size.width - floor((b.size.width * 2.0f) / 3.0f)) < SpectacleWindowCalculationFudgeFactor) && (abs(a.size.height - b.size.height) < SpectacleWindowCalculationFudgeFactor*2)
+#define AlreadyOneHalfOfDisplay(a, b) (abs(a.size.width - (b.size.width / 2.0f)) < SpectacleWindowCalculationFudgeFactor) && (abs(a.size.height - b.size.height) < SpectacleWindowCalculationFudgeFactor*2)
 
 #pragma mark -
 


### PR DESCRIPTION
Some windows like Emacs and Terminal quantize their heights, so they
never satisfy the exact height requirement that triggers cycling from
half to two third to one third.

The original patch by @stevenrobertson and @streeto didn't check height
at all, which prevented this problem but causes an unexpected jump from 
states like top-left-quarter directly to left-two-thirds, when it should stop at
left-half first.

This patch uses the existing `SpectacleWindowCalculationFudgeFactor`
instead. I use double the value for this case, because height is often
quantized to a full line of text, so 8 pixels is not quite enough.
