### PR TITLE
bug fix for move to previous/next third

### DIFF
--- a/SpectacleUtilities.h
+++ b/SpectacleUtilities.h
@@ -5,6 +5,10 @@
 
 #pragma mark -
 
+#define CGRectEqualToRectWithFudge(a, b) ((abs(a.size.width - b.size.width) < (SpectacleWindowCalculationFudgeFactor * 2)) && (abs(a.size.height - b.size.height) < (SpectacleWindowCalculationFudgeFactor * 2)) && (abs(a.origin.x - b.origin.x) < (SpectacleWindowCalculationFudgeFactor * 2)) && (abs(a.origin.y - b.origin.y) < (SpectacleWindowCalculationFudgeFactor * 2)))
+
+#pragma mark -
+
 #define AreaOfRect(a) (CGFloat)(a.size.width * a.size.height)
 
 #pragma mark -

--- a/SpectacleWindowPositionCalculator.h
+++ b/SpectacleWindowPositionCalculator.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "SpectacleWindowPositionManager.h"
+#import "SpectacleUtilities.h"
 
 @interface SpectacleWindowPositionCalculator : NSObject
 

--- a/SpectacleWindowPositionCalculator.m
+++ b/SpectacleWindowPositionCalculator.m
@@ -179,7 +179,7 @@
     for (i = 0; i < thirds.count; i++) {
         CGRect currentWindowRect = [thirds[i] windowRect];
         
-        if (CGRectEqualToRect(currentWindowRect, windowRect)) {
+        if (CGRectEqualToRectWithFudge(currentWindowRect, windowRect)) {
             NSInteger j = i;
             
             if (action == SpectacleWindowActionNextThird) {

--- a/SpectacleWindowPositionManager.m
+++ b/SpectacleWindowPositionManager.m
@@ -232,7 +232,7 @@
     
     CGRect movedWindowRect = [self rectOfWindowWithAccessibilityElement: frontMostWindowElement];
     
-    if (MovingToThirdOfDisplay(action) && !CGRectEqualToRect(movedWindowRect, windowRect)) {
+    if (MovingToThirdOfDisplay(action) && !CGRectEqualToRectWithFudge(movedWindowRect, windowRect)) {
         NSUserDefaults *userDefaults = NSUserDefaults.standardUserDefaults;
         
         NSBeep();


### PR DESCRIPTION
This is a tentative fix for bugs #190, #102 and maybe others... From what I understand, previous/next third commands can't be used with some softwares that use custom sized windows. For instance, my iTerm windows are resized to a multiple of the number of columns, instead of the precise number of pixels calculated by Spectacle. The different sizes make the CGRectEqualToRect() tests fail, and the windows are blacklisted.

This fix allows for some tolerance in the test by comparing the CGRect width/height/x/y parameters +/- the SpectacleWindowCalculationFudgeFactor constant.

The blacklist needs to be emptied before testing:

```
defaults delete com.divisiblebyzero.Spectacle BlacklistedWindowRects
```
