### PR TITLE
Prevent the preferences pane from being resized.

### DIFF
--- a/SpectacleWindowPositionManager.m
+++ b/SpectacleWindowPositionManager.m
@@ -61,6 +61,15 @@
 #pragma mark -
 
 - (void)moveFrontMostWindowWithAction: (SpectacleWindowAction)action {
+    NSString *frontMostWindowName = ZKAccessibilityElement.frontMostApplicationName;
+    NSString *spectacleWindowName = NSBundle.mainBundle.infoDictionary[@"CFBundleName"];
+    
+    if ([frontMostWindowName isEqualToString: spectacleWindowName]) {
+        NSBeep();
+        
+        return;
+    }
+    
     ZKAccessibilityElement *frontMostWindowElement = ZKAccessibilityElement.frontMostWindowElement;
     CGRect frontMostWindowRect = [self rectOfWindowWithAccessibilityElement: frontMostWindowElement];
     CGRect previousFrontMostWindowRect = CGRectNull;


### PR DESCRIPTION
When setting the key bindings it is easy to accidentally resize the preference pane. Thus, this pull request prevents this from happening.
