### PR TITLE
Update status bar item to use template image

### DIFF
--- a/SpectacleApplicationController.m
+++ b/SpectacleApplicationController.m
@@ -145,9 +145,13 @@
 
 - (void)createStatusItem {
     _statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength: NSVariableStatusItemLength];
-
-    _statusItem.image = [[NSImage alloc] initWithContentsOfFile: [NSBundle.mainBundle pathForImageResource: SpectacleStatusItemIcon]];
-    _statusItem.alternateImage = [[NSImage alloc] initWithContentsOfFile: [NSBundle.mainBundle pathForImageResource: SpectacleAlternateStatusItemIcon]];
+    
+    NSImage *statusImage = [[NSImage alloc] initWithContentsOfFile: [NSBundle.mainBundle pathForImageResource:SpectacleStatusItemIcon]];
+    
+    [statusImage setTemplate:YES];
+    
+    _statusItem.image = statusImage;
+    
     _statusItem.highlightMode = YES;
 
     _statusItem.toolTip = [NSString stringWithFormat: @"Spectacle %@", SpectacleUtilities.applicationVersion];


### PR DESCRIPTION
Fixes #229.
![dark](https://cloud.githubusercontent.com/assets/2727279/3621820/c4f7911c-0e1f-11e4-8437-5c3c4af7ce00.png)
![light](https://cloud.githubusercontent.com/assets/2727279/3621821/c50bec3e-0e1f-11e4-914d-e12f2897509c.png)

You'll most likely want to recut the image itself and tweak the drop shadow a bit to make it look great in both design aesthetics.
