### PR TITLE
Cycle in reverse order when calculating moveLeft/moveRight

### DIFF
--- a/Spectacle/SpectacleWindowPositionCalculator.m
+++ b/Spectacle/SpectacleWindowPositionCalculator.m
@@ -185,28 +185,28 @@
     }
 
     if (fabs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneHalfRect)) <= 1.0f) {
-        CGRect oneThirdRect = oneHalfRect;
+        CGRect twoThirdsRect = oneHalfRect;
 
-        oneThirdRect.size.width = floor(visibleFrameOfScreen.size.width / 3.0f);
+        twoThirdsRect.size.width = floor(visibleFrameOfScreen.size.width * 2 / 3.0f);
 
         if (action == SpectacleWindowActionRightHalf) {
-            oneThirdRect.origin.x = visibleFrameOfScreen.origin.x + visibleFrameOfScreen.size.width - oneThirdRect.size.width;
+            twoThirdsRect.origin.x = visibleFrameOfScreen.origin.x + visibleFrameOfScreen.size.width - twoThirdsRect.size.width;
         }
 
         if (RectCentredWithinRect(oneHalfRect, windowRect)) {
-            return oneThirdRect;
-        }
-
-        if (RectCentredWithinRect(oneThirdRect, windowRect)) {
-            CGRect twoThirdsRect = oneHalfRect;
-
-            twoThirdsRect.size.width = floor(visibleFrameOfScreen.size.width * 2 / 3.0f);
-
-            if (action == SpectacleWindowActionRightHalf) {
-                twoThirdsRect.origin.x = visibleFrameOfScreen.origin.x + visibleFrameOfScreen.size.width - twoThirdsRect.size.width;
-            }
-
             return twoThirdsRect;
+        }
+        
+        if (RectCentredWithinRect(twoThirdsRect, windowRect)) {
+            CGRect oneThirdRect = oneHalfRect;
+            
+            oneThirdRect.size.width = floor(visibleFrameOfScreen.size.width / 3.0f);
+            
+            if (action == SpectacleWindowActionRightHalf) {
+                oneThirdRect.origin.x = visibleFrameOfScreen.origin.x + visibleFrameOfScreen.size.width - oneThirdRect.size.width;
+            }
+            
+            return oneThirdRect;
         }
     }
 

--- a/Spectacle/SpectacleWindowPositionCalculator.m
+++ b/Spectacle/SpectacleWindowPositionCalculator.m
@@ -32,6 +32,10 @@
     
     if ((action == SpectacleWindowActionLeftHalf) || (action == SpectacleWindowActionRightHalf)) {
         calculatedWindowRect = [SpectacleWindowPositionCalculator calculateLeftOrRightHalfRect:windowRect visibleFrameOfScreen: visibleFrameOfScreen withAction: action];
+    } else if (action == SpectacleWindowActionFullscreen) {
+        calculatedWindowRect = [SpectacleWindowPositionCalculator calculateTopOrBottomHalfRect: windowRect
+                                                                          visibleFrameOfScreen: visibleFrameOfScreen
+                                                                                    withAction: action];
     } else if ((action == SpectacleWindowActionTopHalf) || (action == SpectacleWindowActionBottomHalf)) {
         calculatedWindowRect.size.width = visibleFrameOfScreen.size.width;
         calculatedWindowRect.size.height = floor(visibleFrameOfScreen.size.height / 2.0f);
@@ -211,6 +215,32 @@
     }
 
     return oneHalfRect;
+}
+
++ (CGRect)calculateTopOrBottomHalfRect: (CGRect)windowRect
+                  visibleFrameOfScreen: (CGRect)visibleFrameOfScreen
+                            withAction: (SpectacleWindowAction)action
+{
+    if (windowRect.size.width == visibleFrameOfScreen.size.width &&
+        windowRect.origin.x   == visibleFrameOfScreen.origin.x)
+    {
+        if (windowRect.size.height == visibleFrameOfScreen.size.height &&
+            windowRect.origin.y    == visibleFrameOfScreen.origin.y)
+        {
+            CGRect topHalfRect = windowRect;
+            topHalfRect.size.height = floor(visibleFrameOfScreen.size.height / 2.0f);
+            topHalfRect.origin.y    = floor(visibleFrameOfScreen.size.height / 2.0f) + visibleFrameOfScreen.origin.y;
+            return topHalfRect;
+        }
+        else if (windowRect.size.height == floor(visibleFrameOfScreen.size.height / 2.0f) &&
+                 windowRect.origin.y    == floor(visibleFrameOfScreen.size.height / 2.0f) + visibleFrameOfScreen.origin.y)
+        {
+            CGRect bottomHalfRect = windowRect;
+            bottomHalfRect.origin.y = visibleFrameOfScreen.origin.y;
+            return bottomHalfRect;
+        }
+    }
+    return visibleFrameOfScreen;
 }
 
 @end


### PR DESCRIPTION
I noticed that some application windows can't shrink to 1/3 of my screen. Thus, I can never cycle through to the 2/3 option using the Move Left/Right hotkey.

This patch will change the cycle order from:
`1/2 -> 1/3 -> 2/3`
to:
`1/2 -> 2/3 -> 1/3`
