### PR TITLE
Fix issues #321 and #323

### DIFF
--- a/Spectacle/SpectacleWindowPositionManager.m
+++ b/Spectacle/SpectacleWindowPositionManager.m
@@ -73,7 +73,12 @@
     
     if (screenOfDisplay) {
         frameOfScreen = NSRectToCGRect([screenOfDisplay frame]);
+        frameOfScreen.size.width++;
+        frameOfScreen.size.height++;
+        
         visibleFrameOfScreen = NSRectToCGRect([screenOfDisplay visibleFrame]);
+        visibleFrameOfScreen.size.width++;
+        visibleFrameOfScreen.size.height++;
     }
 
     if (frontMostWindowElement.isSheet || CGRectIsNull(frontMostWindowRect) || CGRectIsNull(frameOfScreen) || CGRectIsNull(visibleFrameOfScreen) || CGRectEqualToRect(frontMostWindowRect, frameOfScreen)) {


### PR DESCRIPTION
So it appears that the gap between the menu bar and the moved/resized windows is caused by an off by one calculation based on the screen's height. I am completely new to objective-c (as of tonight!) so there is probably a more elegant way to achieve what I have done, which is essentially bumping up the screen width and height by one.

Here is the fix in action:
![screen shot 2015-02-26 at 12 06 34 am](https://cloud.githubusercontent.com/assets/10469602/6387743/779ae148-bd4d-11e4-8219-bcdb66410079.png)

There is still a gap of one pixel, but that appears to be the doing of OSX since I can't drag any window into that area. Other than that, no other unexpected behavior has arisen from this change on my setup.
