### PR TITLE
Change GitHub login link to point to project page

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
 
       	  <h3>Maintained</h3>
 
-      	  <p>If you encounter a problem using Spectacle, or would like to request an enhancement, please log into <a href="https://github.com/login">GitHub</a> and create an <a href="https://github.com/eczarny/spectacle/issues">issue</a>.</p>
+      	  <p>If you encounter a problem using Spectacle, or would like to request an enhancement, please log into <a href="https://github.com/eczarny/spectacle">GitHub</a> and create an <a href="https://github.com/eczarny/spectacle/issues">issue</a>.</p>
 
       	</div>
 


### PR DESCRIPTION
When scanning through the text for a link to the Github page, this is the first one to occur, and it's surprising that it does not lead to the project page.

I know the surrounding text talks about logging in, but maybe we can leave that as an exercise for the reader..? ;)