### PR TITLE
Fix issues #336, #335

### DIFF
--- a/Spectacle/SpectacleWindowPositionManager.m
+++ b/Spectacle/SpectacleWindowPositionManager.m
@@ -270,8 +270,12 @@
             }
             
             // Center the window, taking into account any quantization adjustments.
-            adjustedWindowRect.origin.x += floor((windowRect.size.width - movedWindowRect.size.width) / 2.0f);
-            adjustedWindowRect.origin.y += floor((windowRect.size.height - movedWindowRect.size.height) / 2.0f);
+            float xAdjust = floor((windowRect.size.width - movedWindowRect.size.width) / 2.0f);
+            float yAdjust = floor((windowRect.size.height - movedWindowRect.size.height) / 2.0f);
+            float rightLim = (movedWindowRect.origin.x + movedWindowRect.size.width) - visibleFrameOfScreen.size.width;
+            float bottomLim = (movedWindowRect.origin.y + movedWindowRect.size.height) - visibleFrameOfScreen.size.height;
+            adjustedWindowRect.origin.x += ((xAdjust > 0) * xAdjust) - (rightLim > 0) * rightLim;
+            adjustedWindowRect.origin.y += ((yAdjust > 0) * yAdjust) - (bottomLim > 0) * bottomLim;
             
             [self moveWindowRect:adjustedWindowRect frontMostWindowElement:frontMostWindowElement];
         }

--- a/Spectacle/SpectacleWindowPositionManager.m
+++ b/Spectacle/SpectacleWindowPositionManager.m
@@ -273,7 +273,7 @@
             float xAdjust = floor((windowRect.size.width - movedWindowRect.size.width) / 2.0f);
             float yAdjust = floor((windowRect.size.height - movedWindowRect.size.height) / 2.0f);
             float rightLim = (movedWindowRect.origin.x + movedWindowRect.size.width) - visibleFrameOfScreen.size.width;
-            float bottomLim = (movedWindowRect.origin.y + movedWindowRect.size.height) - visibleFrameOfScreen.size.height;
+            float bottomLim = (movedWindowRect.origin.y + movedWindowRect.size.height) - frameOfScreen.size.height;
             adjustedWindowRect.origin.x += ((xAdjust > 0) * xAdjust) - (rightLim > 0) * rightLim;
             adjustedWindowRect.origin.y += ((yAdjust > 0) * yAdjust) - (bottomLim > 0) * bottomLim;
             


### PR DESCRIPTION
Windows that are being "eaten" on left or right third screen sizes seem to be caused by windows that have a fixed minimum size. Spectacle assumes that the new size created by the left/right hotkeys reflect the actual size when it runs the math to center windows having a fixed size greater than the area.

So this fix just checks to see if the window being adjusted goes off screen, and if so, readjusts the window position so it stays in the screen bounds. 

While I have not tested this on Outlook which the bug request indicated as experiencing this problem, I've found that the "Security & Privacy" window in OSX System Preferences exhibits the same behavior of being "eaten" when switching the size to thirds.