### PR TITLE
Fixed maximizing windows properly when the menu bar & dock are hidden.

### DIFF
--- a/Spectacle/Sources/SpectacleWindowPositionManager.m
+++ b/Spectacle/Sources/SpectacleWindowPositionManager.m
@@ -60,7 +60,7 @@
 
   if (screenOfDisplay) {
     frameOfScreen = NSRectToCGRect([screenOfDisplay frame]);
-    visibleFrameOfScreen = NSRectToCGRect([screenOfDisplay visibleFrame]);
+    visibleFrameOfScreen = NSRectToCGRect([screenOfDisplay frame]);
   }
 
   if (frontmostWindowElement.isSheet
@@ -372,7 +372,7 @@ frontmostWindowElement:(SpectacleAccessibilityElement *)frontmostWindowElement
   CGRect visibleFrameOfScreen = CGRectNull;
 
   if (screenOfDisplay) {
-    visibleFrameOfScreen = NSRectToCGRect(screenOfDisplay.visibleFrame);
+    visibleFrameOfScreen = NSRectToCGRect(screenOfDisplay.frame);
   }
 
   if (![self moveWithHistoryItem:historyItem visibleFrameOfScreen:visibleFrameOfScreen action:action]) {


### PR DESCRIPTION
Spectacle wasn't maximizing windows properly when the dock was hidden (either by using an app such as MenuAndDockless or MenuEclipse, or editing a plist for a specific app manually). This fixes the issue.

(see https://github.com/eczarny/spectacle/issues/277#issuecomment-60177121 for the fix, thanks to @arkrozycki and details of use cases)