### PR TITLE
Fix capitalization so that it compiles on case sensitive OS

### DIFF
--- a/Spectacle/Sources/SpectacleAccessibilityElement.h
+++ b/Spectacle/Sources/SpectacleAccessibilityElement.h
@@ -1,4 +1,4 @@
-#import <AppKit/Appkit.h>
+#import <AppKit/AppKit.h>
 
 #import <Carbon/Carbon.h>
 


### PR DESCRIPTION
I cloned the project, but the compile failed due to a mis-capitalized header name. I installed this machine with case-sensitive HFS.

I have so far not ran the tests (since your contribution guide does not tell me how to do that), however this fix is really minor, changing a single character...