### PR TITLE
Move upper and lower corners between thirds

### DIFF
--- a/Spectacle/Sources/SpectacleWindowAction.h
+++ b/Spectacle/Sources/SpectacleWindowAction.h
@@ -10,7 +10,7 @@
 #define MovingToUpperOrLowerLeftOfDisplay(action) \
   ((action == SpectacleWindowActionUpperLeft) || (action == SpectacleWindowActionLowerLeft))
 
-#define MovingToUpperOrLowerRightDisplay(action) \
+#define MovingToUpperOrLowerRightOfDisplay(action) \
   ((action == SpectacleWindowActionUpperRight) || (action == SpectacleWindowActionLowerRight))
 
 #pragma mark -

--- a/SpectacleSpecs/Sources/SpectacleWindowPositionCalculatorSpec.m
+++ b/SpectacleSpecs/Sources/SpectacleWindowPositionCalculatorSpec.m
@@ -43,35 +43,36 @@ SpecBegin(windowPositionCalculator)
 
     it(@"should calculate a window's CGRect in the left 1/3 of the screen", ^{
       SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 4.0f, 960.0f, 873.0f)
-                                                                             visibleFrameOfScreen:visibleFrameScreen
-                                                                                           action:SpectacleWindowActionLeftHalf];
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionLeftHalf];
 
       expect(result.windowRect).to.equal(CGRectMake(0.0f, 4.0f, 480.0f, 873.0f));
     });
 
     it(@"should calculate a window's CGRect in the right half of the screen", ^{
       SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:windowRect
-                                                                             visibleFrameOfScreen:visibleFrameScreen
-                                                                                           action:SpectacleWindowActionRightHalf];
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionRightHalf];
 
       expect(result.windowRect).to.equal(CGRectMake(720.0f, 4.0f, 720.0f, 873.0f));
     });
 
     it(@"should calculate a window's CGRect in the right 2/3 of the screen", ^{
       SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(720.0f, 4.0f, 720.0f, 873.0f)
-                                                                             visibleFrameOfScreen:visibleFrameScreen
-                                                                                           action:SpectacleWindowActionRightHalf];
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionRightHalf];
 
       expect(result.windowRect).to.equal(CGRectMake(480.0f, 4.0f, 960.0f, 873.0f));
     });
 
     it(@"should calculate a window's CGRect in the right 1/3 of the screen", ^{
       SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(480.0f, 4.0f, 960.0f, 873.0f)
-                                                                             visibleFrameOfScreen:visibleFrameScreen
-                                                                                           action:SpectacleWindowActionRightHalf];
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionRightHalf];
 
       expect(result.windowRect).to.equal(CGRectMake(960.0f, 4.0f, 480.0f, 873.0f));
     });
+      
 
     it(@"should calculate a window's CGRect in the top half of the screen", ^{
       SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:windowRect
@@ -121,36 +122,100 @@ SpecBegin(windowPositionCalculator)
       expect(result.windowRect).to.equal(CGRectMake(0.0f, 4.0f, 1440.0f, 291.0f));
     });
 
-    it(@"should calculate a window's CGRect in the upper left corner of the screen", ^{
-      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:windowRect
+    it(@"should calculate a window's CGRect in the upper left half of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)
                                                                     visibleFrameOfScreen:visibleFrameScreen
                                                                                   action:SpectacleWindowActionUpperLeft];
-
+      
       expect(result.windowRect).to.equal(CGRectMake(0.0f, 441.0f, 720.0f, 436.0f));
     });
 
-    it(@"should calculate a window's CGRect in the lower left corner of the screen", ^{
-      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:windowRect
+    it(@"should calculate a window's CGRect in the upper left 2/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 441.0f, 720.0f, 436.0f)
                                                                     visibleFrameOfScreen:visibleFrameScreen
-                                                                                  action:SpectacleWindowActionLowerLeft];
-
-      expect(result.windowRect).to.equal(CGRectMake(0.0f, 4.0f, 720.0f, 436.0f));
+                                                                                  action:SpectacleWindowActionUpperLeft];
+      
+      expect(result.windowRect).to.equal(CGRectMake(0.0f, 441.0f, 960.0f, 436.0f));
     });
 
-    it(@"should calculate a window's CGRect in the upper right corner of the screen", ^{
-      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:windowRect
+    it(@"should calculate a window's CGRect in the upper left 1/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 441.0f, 960.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionUpperLeft];
+      
+      expect(result.windowRect).to.equal(CGRectMake(0.0f, 441.0f, 480.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the upper right half of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)
                                                                     visibleFrameOfScreen:visibleFrameScreen
                                                                                   action:SpectacleWindowActionUpperRight];
-
+      
       expect(result.windowRect).to.equal(CGRectMake(720.0f, 441.0f, 720.0f, 436.0f));
     });
 
-    it(@"should calculate a window's CGRect in the lower right corner of the screen", ^{
-      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:windowRect
+    it(@"should calculate a window's CGRect in the upper right 2/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(720.0f, 441.0f, 720.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionUpperRight];
+      
+      expect(result.windowRect).to.equal(CGRectMake(480.0f, 441.0f, 960.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the upper right 1/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(480.0f, 441.0f, 960.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionUpperRight];
+      
+      expect(result.windowRect).to.equal(CGRectMake(960.0f, 441.0f, 480.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the lower left half of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionLowerLeft];
+      
+      expect(result.windowRect).to.equal(CGRectMake(0.0f, 4.0f, 720.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the lower left 2/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 4.0f, 720.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionLowerLeft];
+      
+      expect(result.windowRect).to.equal(CGRectMake(0.0f, 4.0f, 960.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the lower left 1/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 4.0f, 960.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionLowerLeft];
+      
+      expect(result.windowRect).to.equal(CGRectMake(0.0f, 4.0f, 480.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the lower right half of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 0.0f, 0.0f, 0.0f)
                                                                     visibleFrameOfScreen:visibleFrameScreen
                                                                                   action:SpectacleWindowActionLowerRight];
-
+      
       expect(result.windowRect).to.equal(CGRectMake(720.0f, 4.0f, 720.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the lower right 2/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(720.0f, 4.0f, 720.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionLowerRight];
+      
+      expect(result.windowRect).to.equal(CGRectMake(480.0f, 4.0f, 960.0f, 436.0f));
+    });
+
+    it(@"should calculate a window's CGRect in the lower right 1/3 of the screen", ^{
+      SpectacleCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(480.0f, 4.0f, 960.0f, 436.0f)
+                                                                    visibleFrameOfScreen:visibleFrameScreen
+                                                                                  action:SpectacleWindowActionLowerRight];
+      
+      expect(result.windowRect).to.equal(CGRectMake(960.0f, 4.0f, 480.0f, 436.0f));
     });
 
     describe(@"next thirds", ^{


### PR DESCRIPTION
Hi! Congratulations for this awesome project!

This PR addresses the issue #541.

Now we should be able to move the upper/lower left/right corners between thirds, just like left/right halves.

<img width="1680" alt="screen shot 2016-03-31 at 10 45 50 pm" src="https://cloud.githubusercontent.com/assets/882253/14195973/1b621d54-f796-11e5-9848-a3d43840ba00.png">
Atom: 2/3 left - Chrome: 1/3 upper right - Terminal: 1/3 lower right


This is what I've done:
- Rename method `MovingToUpperOrLowerRightDisplay` to `MovingToUpperOrLowerRightOfDisplay` to keep consistency with `MovingToUpperOrLowerLeftOfDisplay`
- Add method `calculateCornerRect` to resize the corners into thirds
- Add specs for all upper/lower left/right corners

:beers: 