### PR TITLE
Move corners between thirds

### DIFF
--- a/Spectacle/Resources/Window Position Calculations/SpectacleLowerLeftWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLowerLeftWindowCalculation.js
@@ -1,8 +1,19 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var calculatedWindowRect = SpectacleCalculationHelpers.copyRect(windowRect);
-    calculatedWindowRect.x = visibleFrameOfDestinationScreen.x;
-    calculatedWindowRect.y = visibleFrameOfDestinationScreen.y;
-    calculatedWindowRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    calculatedWindowRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    return calculatedWindowRect;
+    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+        twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+            return twoThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+            return oneThirdsRect;
+        }
+    }
+    return oneQuartRect;
 }, "SpectacleWindowActionLowerLeft");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLowerLeftWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLowerLeftWindowCalculation.js
@@ -1,19 +1,18 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
-        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+    var oneQuarterRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
             oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
             return oneThirdsRect;
         }
     }
-    return oneQuartRect;
+    return oneQuarterRect;
 }, "SpectacleWindowActionLowerLeft");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLowerRightWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLowerRightWindowCalculation.js
@@ -1,8 +1,23 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var calculatedWindowRect = SpectacleCalculationHelpers.copyRect(windowRect);
-    calculatedWindowRect.x = visibleFrameOfDestinationScreen.x + Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    calculatedWindowRect.y = visibleFrameOfDestinationScreen.y;
-    calculatedWindowRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    calculatedWindowRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    return calculatedWindowRect;
+    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    oneQuartRect.x += oneQuartRect.width;
+
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+        twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+            return twoThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+            oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
+            return oneThirdsRect;
+        }
+    }
+
+    return oneQuartRect;
 }, "SpectacleWindowActionLowerRight");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLowerRightWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLowerRightWindowCalculation.js
@@ -1,23 +1,21 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    oneQuartRect.x += oneQuartRect.width;
-
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
-        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+    var oneQuarterRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    oneQuarterRect.x += oneQuarterRect.width;
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
         twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
             oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
             oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
             return oneThirdsRect;
         }
     }
-
-    return oneQuartRect;
+    return oneQuarterRect;
 }, "SpectacleWindowActionLowerRight");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleUpperLeftWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleUpperLeftWindowCalculation.js
@@ -1,21 +1,19 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    oneQuartRect.y += oneQuartRect.height;
-
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
-        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+    var oneQuarterRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    oneQuarterRect.y += oneQuarterRect.height;
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
             oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
             return oneThirdsRect;
         }
     }
-
-    return oneQuartRect;
+    return oneQuarterRect;
 }, "SpectacleWindowActionUpperLeft");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleUpperLeftWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleUpperLeftWindowCalculation.js
@@ -1,8 +1,21 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var calculatedWindowRect = SpectacleCalculationHelpers.copyRect(windowRect);
-    calculatedWindowRect.x = visibleFrameOfDestinationScreen.x;
-    calculatedWindowRect.y = visibleFrameOfDestinationScreen.y + Math.floor(visibleFrameOfDestinationScreen.height / 2.0) + (visibleFrameOfDestinationScreen.height % 2.0);
-    calculatedWindowRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    calculatedWindowRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    return calculatedWindowRect;
+    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    oneQuartRect.y += oneQuartRect.height;
+
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+        twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+            return twoThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+            return oneThirdsRect;
+        }
+    }
+
+    return oneQuartRect;
 }, "SpectacleWindowActionUpperLeft");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleUpperRightWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleUpperRightWindowCalculation.js
@@ -1,8 +1,24 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var calculatedWindowRect = SpectacleCalculationHelpers.copyRect(windowRect);
-    calculatedWindowRect.x = visibleFrameOfDestinationScreen.x + Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    calculatedWindowRect.y = visibleFrameOfDestinationScreen.y + Math.floor(visibleFrameOfDestinationScreen.height / 2.0) + (visibleFrameOfDestinationScreen.height % 2.0);
-    calculatedWindowRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    calculatedWindowRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    return calculatedWindowRect;
+    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    oneQuartRect.x += oneQuartRect.width;
+    oneQuartRect.y += oneQuartRect.height;
+
+		if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+        twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
+        twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+            return twoThirdRect;
+        }
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
+            oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
+            return oneThirdsRect;
+        }
+    }
+
+    return oneQuartRect;
 }, "SpectacleWindowActionUpperRight");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleUpperRightWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleUpperRightWindowCalculation.js
@@ -1,24 +1,22 @@
 windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneQuartRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneQuartRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
-    oneQuartRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
-    oneQuartRect.x += oneQuartRect.width;
-    oneQuartRect.y += oneQuartRect.height;
-
-		if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuartRect)) <= 1.0) {
-        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+    var oneQuarterRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
+    oneQuarterRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 2.0);
+    oneQuarterRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 2.0);
+    oneQuarterRect.x += oneQuarterRect.width;
+    oneQuarterRect.y += oneQuarterRect.height;
+    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneQuarterRect)) <= 1.0) {
+        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
         twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
         twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuartRect, windowRect)) {
+        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneQuarterRect, windowRect)) {
             return twoThirdRect;
         }
         if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuartRect);
+            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneQuarterRect);
             oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
             oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
             return oneThirdsRect;
         }
     }
-
-    return oneQuartRect;
+    return oneQuarterRect;
 }, "SpectacleWindowActionUpperRight");

--- a/SpectacleSpecs/Sources/SpectacleUpperLeftWindowCalculationSpec.m
+++ b/SpectacleSpecs/Sources/SpectacleUpperLeftWindowCalculationSpec.m
@@ -17,7 +17,25 @@ describe(@"SpectacleUpperLeftWindowCalculation", ^{
                                                                           visibleFrameOfSourceScreen:visibleFrameSourceScreen
                                                                      visibleFrameOfDestinationScreen:visibleFrameDestinationScreen
                                                                                               action:kSpectacleWindowActionUpperLeft];
-    expect(result.windowRect).to.equal(CGRectMake(0.0f, 441.0f, 720.0f, 436.0f));
+    expect(result.windowRect).to.equal(CGRectMake(0.0f, 440.0f, 720.0f, 436.0f));
   });
+  
+  it(@"should calculate a window's CGRect in the left 2/3 of the screen", ^{
+    SpectacleWindowPositionCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 440.0f, 720.0f, 436.0f)
+                                                                          visibleFrameOfSourceScreen:visibleFrameSourceScreen
+                                                                     visibleFrameOfDestinationScreen:visibleFrameDestinationScreen
+                                                                                              action:kSpectacleWindowActionUpperLeft];
+    expect(result.windowRect).to.equal(CGRectMake(0.0f, 440.0f, 960.0f, 436.0f));
+  });
+  
+  it(@"should calculate a window's CGRect in the left 1/3 of the screen", ^{
+    SpectacleWindowPositionCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(0.0f, 440.0f, 960.0f, 436.0f)
+                                                                          visibleFrameOfSourceScreen:visibleFrameSourceScreen
+                                                                     visibleFrameOfDestinationScreen:visibleFrameDestinationScreen
+                                                                                              action:kSpectacleWindowActionUpperLeft];
+    expect(result.windowRect).to.equal(CGRectMake(0.0f, 440.0f, 480.0f, 436.0f));
+  });
+
+  
 });
 SpecEnd

--- a/SpectacleSpecs/Sources/SpectacleUpperRightWindowCalculationSpec.m
+++ b/SpectacleSpecs/Sources/SpectacleUpperRightWindowCalculationSpec.m
@@ -17,7 +17,24 @@ describe(@"SpectacleUpperRightWindowCalculation", ^{
                                                                           visibleFrameOfSourceScreen:visibleFrameSourceScreen
                                                                      visibleFrameOfDestinationScreen:visibleFrameDestinationScreen
                                                                                               action:kSpectacleWindowActionUpperRight];
-    expect(result.windowRect).to.equal(CGRectMake(720.0f, 441.0f, 720.0f, 436.0f));
+    expect(result.windowRect).to.equal(CGRectMake(720.0f, 440.0f, 720.0f, 436.0f));
   });
+  
+  it(@"should calculate a window's CGRect in the upper right 2/3 corner of the screen", ^{
+    SpectacleWindowPositionCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(720.0f, 440.0f, 720.0f, 436.0f)
+                                                                          visibleFrameOfSourceScreen:visibleFrameSourceScreen
+                                                                     visibleFrameOfDestinationScreen:visibleFrameDestinationScreen
+                                                                                              action:kSpectacleWindowActionUpperRight];
+    expect(result.windowRect).to.equal(CGRectMake(480.0f, 440.0f, 960.0f, 436.0f));
+  });
+  
+  it(@"should calculate a window's CGRect in the upper right 1/3 corner of the screen", ^{
+    SpectacleWindowPositionCalculationResult *result = [windowPositionCalculator calculateWindowRect:CGRectMake(480.0f, 440.0f, 960.0f, 436.0f)
+                                                                          visibleFrameOfSourceScreen:visibleFrameSourceScreen
+                                                                     visibleFrameOfDestinationScreen:visibleFrameDestinationScreen
+                                                                                              action:kSpectacleWindowActionUpperRight];
+    expect(result.windowRect).to.equal(CGRectMake(960.0f, 440.0f, 480.0f, 436.0f));
+  });
+
 });
 SpecEnd


### PR DESCRIPTION
Hi just did the changes for the issue #541. It is another tentative for the PR #561.

We can now move the upper/lower left/right corners between thirds. For example:

<img width="1680" alt="example" src="https://cloud.githubusercontent.com/assets/160922/19486538/c1fec51c-9599-11e6-87cf-9a2af4e508a3.png">
Where Sublime Text has: 2/3 left, where Chrome is 1/3 upper right  and iTerm2: 1/3 lower right

Thank you for this amazing app!
