### PR TITLE
Remove gap from left/right

### DIFF
--- a/Spectacle/Sources/SpectacleWindowPositionManager.h
+++ b/Spectacle/Sources/SpectacleWindowPositionManager.h
@@ -37,4 +37,49 @@ SPECTACLE_INIT_AND_NEW_UNAVAILABLE
 - (void)undoLastWindowAction;
 - (void)redoLastWindowAction;
 
+typedef enum {
+    kCoreDockOrientationTop = 1,
+    kCoreDockOrientationBottom = 2,
+    kCoreDockOrientationLeft = 3,
+    kCoreDockOrientationRight = 4
+} CoreDockOrientation;
+
+typedef enum {
+    kCoreDockPinningStart = 1,
+    kCoreDockPinningMiddle = 2,
+    kCoreDockPinningEnd = 3
+} CoreDockPinning;
+
+typedef enum {
+    kCoreDockEffectGenie = 1,
+    kCoreDockEffectScale = 2,
+    kCoreDockEffectSuck = 3
+} CoreDockEffect;
+
+// Tile size ranges from 0.0 to 1.0.
+extern float CoreDockGetTileSize(void);
+extern void CoreDockSetTileSize(float tileSize);
+
+extern void CoreDockGetOrientationAndPinning(CoreDockOrientation *outOrientation, CoreDockPinning *outPinning);
+// If you only want to set one, use 0 for the other.
+extern void CoreDockSetOrientationAndPinning(CoreDockOrientation orientation, CoreDockPinning pinning);
+
+extern void CoreDockGetEffect(CoreDockEffect *outEffect);
+extern void CoreDockSetEffect(CoreDockEffect effect);
+
+extern Boolean CoreDockGetAutoHideEnabled(void);
+extern void CoreDockSetAutoHideEnabled(Boolean flag);
+
+extern Boolean CoreDockIsMagnificationEnabled(void);
+extern void CoreDockSetMagnificationEnabled(Boolean flag);
+
+// Magnification ranges from 0.0 to 1.0.
+extern float CoreDockGetMagnificationSize(void);
+extern void CoreDockSetMagnificationSize(float newSize);
+
+extern Boolean CoreDockGetWorkspacesEnabled(void);
+extern void CoreDockSetWorkspacesEnabled(Boolean); // This works, but wipes out all of the other spaces prefs. An alternative is to use the ScriptingBridge which works just fine.
+
+extern void CoreDockGetWorkspacesCount(int *rows, int *cols);
+extern void CoreDockSetWorkspacesCount(int rows, int cols);
 @end


### PR DESCRIPTION
It is easy to remove the gap on the left.

It is difficult to remove the gap on the right,
but if change the orienation to the left, it is also becomes easy:

    if dock_is_hidden
        if orienation_not_left
            change_orienation_to_left

    move_window_element
    ...

    if orienation_changed
        resotre_orienation

Test environment：

-  MBP early-2011 (OSX 10.11.5)
- rMBP mid-2014 (OSX 10.11.5) with external Monitor