### PR TITLE
Additional strategy to move windows around

### DIFF
--- a/Spectacle/Resources/Localizations/Base.lproj/SpectaclePreferencesWindow.xib
+++ b/Spectacle/Resources/Localizations/Base.lproj/SpectaclePreferencesWindow.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="MacOSX.Cocoa" propertyAccessControl="localizable">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11762"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -44,7 +44,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="616" height="513"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField verticalHuggingPriority="750" id="Nwx-2P-V9U">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="Nwx-2P-V9U">
                         <rect key="frame" x="18" y="451" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Center:" id="oqf-7z-BFa">
@@ -57,7 +57,7 @@
                         <rect key="frame" x="140" y="449" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="guf-X1-Beb">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="guf-X1-Beb">
                         <rect key="frame" x="18" y="422" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Fullscreen:" id="tKr-XE-DEU">
@@ -70,10 +70,10 @@
                         <rect key="frame" x="140" y="420" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="uY3-hc-TbA">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="uY3-hc-TbA">
                         <rect key="frame" x="18" y="364" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Left Half:" id="IWj-rc-Kvi">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Left:" id="IWj-rc-Kvi">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -83,10 +83,10 @@
                         <rect key="frame" x="140" y="362" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="Gsd-o4-KTI">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="Gsd-o4-KTI">
                         <rect key="frame" x="18" y="335" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Right Half:" id="WeK-fS-mRh">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Right:" id="WeK-fS-mRh">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -96,10 +96,10 @@
                         <rect key="frame" x="140" y="333" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="edj-pC-f1Z">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="edj-pC-f1Z">
                         <rect key="frame" x="17" y="306" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Top Half:" id="AnP-Lv-Hbd">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Top:" id="AnP-Lv-Hbd">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -109,10 +109,10 @@
                         <rect key="frame" x="140" y="304" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="Dcf-0q-9fG">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="Dcf-0q-9fG">
                         <rect key="frame" x="18" y="277" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bottom Half:" id="Awn-mO-sht">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Bottom:" id="Awn-mO-sht">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -122,7 +122,7 @@
                         <rect key="frame" x="140" y="275" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="jQx-Df-xE5">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="jQx-Df-xE5">
                         <rect key="frame" x="18" y="219" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Upper Left:" id="ldH-1E-mKW">
@@ -135,7 +135,7 @@
                         <rect key="frame" x="140" y="217" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="b4f-8J-iOX">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="b4f-8J-iOX">
                         <rect key="frame" x="18" y="190" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Lower Left:" id="dQP-TR-GMx">
@@ -148,7 +148,7 @@
                         <rect key="frame" x="140" y="188" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="Q8S-XZ-uUw">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="Q8S-XZ-uUw">
                         <rect key="frame" x="18" y="161" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Upper Right:" id="gSY-Au-xOH">
@@ -161,7 +161,7 @@
                         <rect key="frame" x="140" y="159" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="NRc-if-7b9">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="NRc-if-7b9">
                         <rect key="frame" x="18" y="132" width="117" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Lower Right:" id="Vul-FT-BbB">
@@ -174,7 +174,7 @@
                         <rect key="frame" x="140" y="130" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="4P4-9k-sEd">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="4P4-9k-sEd">
                         <rect key="frame" x="286" y="451" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Next Display:" id="lw7-Ap-kJO">
@@ -187,7 +187,7 @@
                         <rect key="frame" x="422" y="449" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="aQq-n4-9FK">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="aQq-n4-9FK">
                         <rect key="frame" x="286" y="422" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Previous Display:" id="hmL-EC-pro">
@@ -200,7 +200,7 @@
                         <rect key="frame" x="422" y="420" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="sBC-FW-cjv">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="sBC-FW-cjv">
                         <rect key="frame" x="286" y="364" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Next Third:" id="Tze-mR-IV4">
@@ -213,7 +213,7 @@
                         <rect key="frame" x="422" y="362" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="FjH-Ke-3MT">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="FjH-Ke-3MT">
                         <rect key="frame" x="286" y="335" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Previous Third:" id="s3E-Lp-mJ4">
@@ -226,7 +226,7 @@
                         <rect key="frame" x="422" y="333" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="sIx-hc-eUS">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="sIx-hc-eUS">
                         <rect key="frame" x="286" y="277" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Make Larger:" id="0f9-kj-bro">
@@ -239,7 +239,7 @@
                         <rect key="frame" x="422" y="275" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="Iw5-TM-YRu">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="Iw5-TM-YRu">
                         <rect key="frame" x="286" y="248" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Make Smaller:" id="SDM-U5-yUR">
@@ -252,7 +252,7 @@
                         <rect key="frame" x="422" y="246" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="lYA-bE-Cvq">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="lYA-bE-Cvq">
                         <rect key="frame" x="286" y="190" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Undo:" id="CJs-az-eG7">
@@ -265,7 +265,7 @@
                         <rect key="frame" x="422" y="188" width="140" height="21"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     </customView>
-                    <textField verticalHuggingPriority="750" id="paN-Mc-McA">
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="paN-Mc-McA">
                         <rect key="frame" x="286" y="161" width="131" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Redo:" id="y7M-cR-DF2">
@@ -290,7 +290,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="616" height="63"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="t8o-hT-IQi">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="t8o-hT-IQi">
                                         <rect key="frame" x="191" y="25" width="28" height="29"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="⌃" id="806-S1-nYH">
@@ -299,7 +299,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="dj1-Cv-cGv">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="dj1-Cv-cGv">
                                         <rect key="frame" x="174" y="9" width="63" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Control" id="7Fe-Da-fYB">
@@ -308,7 +308,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="l4c-Va-boE">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="l4c-Va-boE">
                                         <rect key="frame" x="258" y="25" width="32" height="29"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="⌥" id="YQm-Kc-fYF">
@@ -317,7 +317,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="T1t-0q-VR1">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="T1t-0q-VR1">
                                         <rect key="frame" x="243" y="9" width="63" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Option" id="U0H-hG-KAQ">
@@ -326,7 +326,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="dWs-aZ-UsN">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="dWs-aZ-UsN">
                                         <rect key="frame" x="325" y="25" width="32" height="29"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="⇧" id="Ir0-AJ-ldj">
@@ -335,7 +335,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="T2K-sG-8h4">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="T2K-sG-8h4">
                                         <rect key="frame" x="310" y="9" width="63" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Shift" id="dww-8Q-sa1">
@@ -344,7 +344,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ePN-Nc-cy9">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="ePN-Nc-cy9">
                                         <rect key="frame" x="394" y="25" width="32" height="29"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="⌘" id="SQM-4e-yFd">
@@ -353,7 +353,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" id="Xwv-Yf-TxZ">
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="Xwv-Yf-TxZ">
                                         <rect key="frame" x="379" y="9" width="63" height="17"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Command" id="jdf-Yu-zrq">
@@ -417,7 +417,7 @@
                         <action selector="swapFooterViews:" target="-2" id="U7e-9q-8hA"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" id="U91-cx-ccf">
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" id="U91-cx-ccf">
                     <rect key="frame" x="297" y="23" width="74" height="17"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Run..." id="eYU-TH-wcO">

--- a/Spectacle/Resources/Window Position Calculations/SpectacleBottomHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleBottomHalfWindowCalculation.js
@@ -1,17 +1,11 @@
-windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneHalfRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneHalfRect.height = Math.floor(oneHalfRect.height / 2.0);
-    if (Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneHalfRect)) <= 1.0) {
-        var twoThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-        twoThirdsRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
-            return twoThirdsRect;
+windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(
+    function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
+        if (SpectacleCalculationHelpers.isBottomHalf(windowRect, visibleFrameOfDestinationScreen)) {
+            return SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
         }
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdsRect, windowRect)) {
-            var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
-            return oneThirdRect;
-        }
-    }
-    return oneHalfRect;
-}, "SpectacleWindowActionBottomHalf");
+
+        var r = SpectacleCalculationHelpers.isLeftOrRightHalf(windowRect, visibleFrameOfDestinationScreen) ?
+            windowRect : visibleFrameOfDestinationScreen;
+
+        return SpectacleCalculationHelpers.calcBottomHalf(r);
+    }, "SpectacleWindowActionBottomHalf");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleLeftHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleLeftHalfWindowCalculation.js
@@ -1,17 +1,11 @@
-windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneHalfRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneHalfRect.width = Math.floor(oneHalfRect.width / 2.0);
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneHalfRect)) <= 1.0) {
-        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-        twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
-            return twoThirdRect;
+windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(
+    function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
+        if (SpectacleCalculationHelpers.isLeftHalf(windowRect, visibleFrameOfDestinationScreen)) {
+            return SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
         }
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            return oneThirdsRect;
-        }
-    }
-    return oneHalfRect;
-}, "SpectacleWindowActionLeftHalf");
+
+        var r = SpectacleCalculationHelpers.isTopOrBottomHalf(windowRect, visibleFrameOfDestinationScreen) ?
+            windowRect : visibleFrameOfDestinationScreen;
+
+        return SpectacleCalculationHelpers.calcLeftHalf(r);
+    }, "SpectacleWindowActionLeftHalf");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleRightHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleRightHalfWindowCalculation.js
@@ -1,20 +1,11 @@
-windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneHalfRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneHalfRect.width = Math.floor(oneHalfRect.width / 2.0);
-    oneHalfRect.x += oneHalfRect.width;
-    if (Math.abs(CGRectGetMidY(windowRect) - CGRectGetMidY(oneHalfRect)) <= 1.0) {
-        var twoThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-        twoThirdRect.width = Math.floor(visibleFrameOfDestinationScreen.width * 2 / 3.0);
-        twoThirdRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - twoThirdRect.width;
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
-            return twoThirdRect;
+windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(
+    function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
+        if (SpectacleCalculationHelpers.isRightHalf(windowRect, visibleFrameOfDestinationScreen)) {
+            return SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
         }
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdRect, windowRect)) {
-            var oneThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdsRect.width = Math.floor(visibleFrameOfDestinationScreen.width / 3.0);
-            oneThirdsRect.x = visibleFrameOfDestinationScreen.x + visibleFrameOfDestinationScreen.width - oneThirdsRect.width;
-            return oneThirdsRect;
-        }
-    }
-    return oneHalfRect;
-}, "SpectacleWindowActionRightHalf");
+
+        var r = SpectacleCalculationHelpers.isTopOrBottomHalf(windowRect, visibleFrameOfDestinationScreen) ?
+            windowRect : visibleFrameOfDestinationScreen;
+
+        return SpectacleCalculationHelpers.calcRightHalf(r);
+    }, "SpectacleWindowActionRightHalf");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleTopHalfWindowCalculation.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleTopHalfWindowCalculation.js
@@ -1,20 +1,11 @@
-windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
-    var oneHalfRect = SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
-    oneHalfRect.height = Math.floor(oneHalfRect.height / 2.0);
-    oneHalfRect.y += oneHalfRect.height + (visibleFrameOfDestinationScreen.height % 2.0);
-    if (Math.abs(CGRectGetMidX(windowRect) - CGRectGetMidX(oneHalfRect)) <= 1.0) {
-        var twoThirdsRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-        twoThirdsRect.height = Math.floor(visibleFrameOfDestinationScreen.height * 2 / 3.0);
-        twoThirdsRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - twoThirdsRect.height;
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(oneHalfRect, windowRect)) {
-            return twoThirdsRect;
+windowPositionCalculationRegistry.registerWindowPositionCalculationWithAction(
+    function (windowRect, visibleFrameOfSourceScreen, visibleFrameOfDestinationScreen) {
+        if (SpectacleCalculationHelpers.isTopHalf(windowRect, visibleFrameOfDestinationScreen)) {
+            return SpectacleCalculationHelpers.copyRect(visibleFrameOfDestinationScreen);
         }
-        if (SpectacleCalculationHelpers.rectCenteredWithinRect(twoThirdsRect, windowRect)) {
-            var oneThirdRect = SpectacleCalculationHelpers.copyRect(oneHalfRect);
-            oneThirdRect.height = Math.floor(visibleFrameOfDestinationScreen.height / 3.0);
-            oneThirdRect.y = visibleFrameOfDestinationScreen.y + visibleFrameOfDestinationScreen.height - oneThirdRect.height;
-            return oneThirdRect;
-        }
-    }
-    return oneHalfRect;
+
+        var r = SpectacleCalculationHelpers.isLeftOrRightHalf(windowRect, visibleFrameOfDestinationScreen) ?
+            windowRect : visibleFrameOfDestinationScreen;
+
+        return SpectacleCalculationHelpers.calcTopHalf(r);
 }, "SpectacleWindowActionTopHalf");

--- a/Spectacle/Resources/Window Position Calculations/SpectacleWindowCalculationHelpers.js
+++ b/Spectacle/Resources/Window Position Calculations/SpectacleWindowCalculationHelpers.js
@@ -15,9 +15,68 @@ var SpectacleCalculationHelpers = (function () {
     var rectFitsWithinRect = function(rect1, rect2) {
         return (rect1.width <= rect2.width) && (rect1.height <= rect2.height);
     };
+    var almostEqual = function(rect1, rect2) {
+        if (Math.abs(rect1.x - rect2.x) > 10) return false;
+        if (Math.abs(rect1.y - rect2.y) > 10) return false;
+        if (Math.abs(rect1.x + rect1.width - rect2.x - rect2.width) > 10) return false;
+        if (Math.abs(rect1.y + rect1.height - rect2.y - rect2.height) > 10) return false;
+
+        return true;
+    };
+    var calcLeftHalf = function(rect) {
+        var left = copyRect(rect);
+        left.width = Math.floor(left.width / 2.0);
+        return left;
+    };
+    var calcRightHalf = function(rect) {
+        var right = copyRect(rect);
+        right.width = Math.floor(right.width / 2.0);
+        right.x += right.width + (rect.width % 2.0);
+        return right;
+    };
+    var calcTopHalf = function(rect) {
+        var upperHalf = copyRect(rect);
+        upperHalf.height = Math.floor(upperHalf.height / 2.0);
+        upperHalf.y += upperHalf.height + (rect.height % 2.0);
+        return upperHalf;
+    };
+    var calcBottomHalf = function(rect) {
+        var bottomHalf = copyRect(rect);
+        bottomHalf.height = Math.floor(bottomHalf.height / 2.0);
+        return bottomHalf;
+    };
+    var isLeftHalf = function(rect, total) {
+        return almostEqual(rect, calcLeftHalf(total));
+    };
+    var isRightHalf = function(rect, total) {
+        return almostEqual(rect, calcRightHalf(total));
+    };
+    var isLeftOrRightHalf = function(rect, total) {
+        return isLeftHalf(rect, total) || isRightHalf(rect, total);
+    };
+    var isTopHalf = function(rect, total) {
+        return almostEqual(rect, calcTopHalf(total));
+    };
+    var isBottomHalf = function(rect, total) {
+        return almostEqual(rect, calcBottomHalf(total));
+    };
+    var isTopOrBottomHalf = function(rect, total) {
+        return isTopHalf(rect, total) || isBottomHalf(rect, total);
+    };
     return {
         copyRect: copyRect,
         rectCenteredWithinRect: rectCenteredWithinRect,
         rectFitsWithinRect: rectFitsWithinRect,
+        almostEqual: almostEqual,
+        isLeftHalf: isLeftHalf,
+        isRightHalf: isRightHalf,
+        isLeftOrRightHalf: isLeftOrRightHalf,
+        isTopHalf: isTopHalf,
+        isBottomHalf: isBottomHalf,
+        isTopOrBottomHalf: isTopOrBottomHalf,
+        calcTopHalf: calcTopHalf,
+        calcBottomHalf: calcBottomHalf,
+        calcLeftHalf: calcLeftHalf,
+        calcRightHalf: calcRightHalf,
     };
 })();


### PR DESCRIPTION
First of all, I use spectacle every day (mainly for the fullscreen mode).

a colleague of mine started also using osx and asked about a special form of window-movements (that he has configured for his linux box). Is uses less shortscuts but support still his main usecase (splitting the screen into halves or quarters).

If the windows is somewhere and you move it into a direction it takes e.g. the top half of the screen, if you continue moving in this direction it takes the full screen. if you have half of a screen and use a direction 90degress to the original one the window is halved again (end result is a quarter of the screen in one corner).

i implemented this by replacing your *half movements. Perhaps you can add this correctly to the system.

I also tried to add this to the system additionally to the existing operations, but at some point i got into problems with preference settings and also with the layout and function of the preference screen. As you see, I am not used to develop osx apps with interface builder.

one more questions:
the last usecase that with this change is now missing for my friend is that the window always remembers the last free floating position that was not managed by spectacle. i saw you have a history for the undo/redo operations, but i am not sure if this works on a per window basis. Is there a way to attach a generic attribute e.g. a string to any window (so that this information could be transported that way?)