### PR TITLE
Preserve the order of shortcuts in Shortcuts.json

### DIFF
--- a/Spectacle/Sources/SpectacleShortcutJSONStorage.m
+++ b/Spectacle/Sources/SpectacleShortcutJSONStorage.m
@@ -84,7 +84,12 @@ static NSArray<NSDictionary *> *jsonObjectFromShortcuts(NSArray<SpectacleShortcu
                            @"shortcut_key_binding" : shortcut.shortcutKeyBinding ?: [NSNull null],
                            }];
   }
-  return jsonArray;
+
+  NSSortDescriptor *sortDescriptor;
+  sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"shortcut_name" ascending:YES];
+  NSArray *sortedJSONArray = [jsonArray sortedArrayUsingDescriptors:@[sortDescriptor]];
+
+  return sortedJSONArray;
 }
 
 static NSArray<SpectacleShortcut *> *shortcutsFromJsonObject(NSArray<NSDictionary *> *jsonArray, SpectacleShortcutAction action)


### PR DESCRIPTION
This fixes #711 by sorting the JSON array by `shortcut_name` before writing to the file.