### PR TITLE
Make footer of website sticky with Flexbox

### DIFF
--- a/stylesheets/all.css
+++ b/stylesheets/all.css
@@ -62,6 +62,9 @@ table {
 
 /* line 6, stylesheets/all.css.sass */
 body {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
   color: #333333;
   -webkit-animation: load 2s;
   -moz-animation: load 2s;
@@ -109,6 +112,7 @@ img {
 
 /* line 19, stylesheets/all.css.sass */
 .container {
+  flex: 1;
   width: 90%;
   max-width: 960px;
   margin: auto; }


### PR DESCRIPTION
Make the footer of the website stick to the bottom of the page if there isn't enough content on the screen to push it down.

Before: 
<img width="1172" alt="screenshot of google chrome 17-09-18 4-16-32 pm" src="https://user-images.githubusercontent.com/811954/45605928-10d3a780-ba95-11e8-9673-b94fe27f2ec3.png">


After:
<img width="1169" alt="screenshot of google chrome 17-09-18 4-14-37 pm" src="https://user-images.githubusercontent.com/811954/45605915-e84bad80-ba94-11e8-8626-ecc43d3585d4.png">

